### PR TITLE
Fixed MPI_Get_library_version using string

### DIFF
--- a/lemonspotter/core/parameter.py
+++ b/lemonspotter/core/parameter.py
@@ -2,7 +2,7 @@
 This module contains the class definition of Parameter.
 """
 
-from typing import Dict, Any
+from typing import Dict, Any, Optional
 from enum import Enum
 
 from lemonspotter.core.database import Database
@@ -49,3 +49,11 @@ class Parameter:
             raise Exception('Direction is not in JSON.')
 
         return Direction(self._json['direction'])
+
+    @property
+    def length(self) -> Optional[str]:
+        """
+        This property, if not None, provides the length of the parameter.
+        """
+
+        return self._json.get('length', None)

--- a/lemonspotter/samplers/valid.py
+++ b/lemonspotter/samplers/valid.py
@@ -109,7 +109,12 @@ class ValidSampler(Sampler):
         type_samples = []
 
         if parameter.direction == Direction.OUT:
-            if parameter.type.dereferencable:
+            if parameter.type.abstract_type == 'STRING':
+                mem_alloc = f'malloc({parameter.length} * sizeof(char))'
+                var = Variable(parameter.type, parameter.name + '_out', mem_alloc)
+                type_samples.append(var)
+
+            elif parameter.type.dereferencable:
                 mem_alloc = f'malloc(sizeof({parameter.type.dereference().language_type}))'
                 var = Variable(parameter.type, parameter.name + '_out', mem_alloc)
                 type_samples.append(var)


### PR DESCRIPTION
Partially fixes usage of string type and length property of a parameter.

This is not a full solution to all cases in MPI.